### PR TITLE
Increase RAM for Vagrant VM to allow Bundle Install

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,5 +16,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Uncomment the following line if you want a GUI.
     # vb.gui = true
     vb.name = "markus"
+    vb.memory = 2048
   end
 end


### PR DESCRIPTION
This allows the `bundle install` command on new Vagrant machines to run without a out of memory issue. Default RAM allocation is only 512 mb.
